### PR TITLE
Add timestamp (needs testing)

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -4,6 +4,7 @@ DROP TABLE logs;
 
 CREATE TABLE logs (
        id SERIAL,
+       received timestamp default now(),
        privalversion text,
        time text,
        hostname text,

--- a/schema.sql
+++ b/schema.sql
@@ -4,7 +4,7 @@ DROP TABLE logs;
 
 CREATE TABLE logs (
        id SERIAL,
-       received timestamp default now(),
+       received timestamp with time zone default now(),
        privalversion text,
        time text,
        hostname text,


### PR DESCRIPTION
Timestamp of log reception needs to be added if we are to measure and compare latency.

Waiting on heroku deployer to be stable before testing...

/cc @apg 
